### PR TITLE
Misc. fixes for WiFI, MQTT, HTTP, and Location

### DIFF
--- a/firmware/components/ha_mqtt/esp_discovery.c
+++ b/firmware/components/ha_mqtt/esp_discovery.c
@@ -74,8 +74,6 @@ char* esp_discovery_serialize_number(esp_discovery_number_t *discovery)
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
 
-	char *jsonString = cJSON_PrintUnformatted(root);
-
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
 	cJSON_AddStringToObject(root, "name", discovery->name);
@@ -144,7 +142,6 @@ char* esp_discovery_serialize_button(esp_discovery_button_t *discovery)
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -206,7 +203,6 @@ char* esp_discovery_serialize_switch(esp_discovery_switch_t *discovery)
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -234,7 +230,6 @@ char* esp_discovery_serialize_room_presence(esp_discovery_room_presence_t *disco
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -317,7 +312,6 @@ char* esp_discovery_serialize_pir_sensor(esp_discovery_pir_sensor_t *discovery)
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -390,7 +384,6 @@ char* esp_discovery_serialize_macro_move_sensor(esp_discovery_macro_move_sensor_
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -448,7 +441,6 @@ char* esp_discovery_serialize_micro_move_sensor(esp_discovery_micro_move_sensor_
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -506,7 +498,6 @@ char* esp_discovery_serialize_light_sensor(esp_discovery_light_sensor_t *discove
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
@@ -588,8 +579,6 @@ char* esp_discovery_serialize_sensor(esp_discovery_sensor_t *discovery)
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
 
-	char *jsonString = cJSON_PrintUnformatted(root);
-
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);
 	cJSON_AddStringToObject(root, "name", discovery->name);
@@ -667,8 +656,6 @@ char* esp_discovery_serialize_text(esp_discovery_text_t *discovery)
 			{ "RoomSense" }, 1);
 	cJSON_AddItemToObject(device, "identifiers", identifiers);
 	cJSON_AddStringToObject(device, "name", "RoomSense IQ");
-
-	char *jsonString = cJSON_PrintUnformatted(root);
 
 	cJSON_AddStringToObject(root, "platform", discovery->platform);
 	cJSON_AddStringToObject(root, "schema", discovery->schema);

--- a/firmware/components/ha_mqtt/ha_mqtt.c
+++ b/firmware/components/ha_mqtt/ha_mqtt.c
@@ -1630,6 +1630,7 @@ static void mqtt_app_task(void *pvParameters)
 				{
 					ESP_LOGI(TAG, "saved Credentials.");
 					app_nvs_save_mqtt_creds();
+					xEventGroupSetBits(mqtt_app_event_group, MQTT_APP_CONNECTING_USING_SAVED_CREDS_BIT);
 				}
 				if (eventBits & MQTT_APP_CONNECTING_FROM_HTTP_SERVER_BIT)
 				{
@@ -1641,7 +1642,6 @@ static void mqtt_app_task(void *pvParameters)
 			case MQTT_APP_MSG_DISCONNECTED:
 				ESP_LOGI(TAG, "MQTT_APP_MSG_DISCONNECTED");
 				g_mqtt_connection_status = false;
-				xEventGroupClearBits(mqtt_app_event_group, MQTT_APP_CONNECTING_USING_SAVED_CREDS_BIT);
 				xEventGroupClearBits(mqtt_app_event_group, MQTT_APP_CONNECTING_FROM_HTTP_SERVER_BIT);
 
 				if (roomsense_iq_shared.wifi_app_shared.g_wifi_connection_status == true)
@@ -1671,6 +1671,8 @@ static void mqtt_app_task(void *pvParameters)
 
 					mqtt_cfg.username = NULL;
 					mqtt_cfg.password = NULL;
+
+					xEventGroupClearBits(mqtt_app_event_group, MQTT_APP_CONNECTING_USING_SAVED_CREDS_BIT);
 
 					//mqtt_app_send_message(MQTT_APP_MSG_LOAD_SAVED_CREDENTIALS);
 

--- a/firmware/main/http_server.c
+++ b/firmware/main/http_server.c
@@ -25,8 +25,7 @@
 #include "dashboard.h"
 
 bool g_ws_pause = false;
-static char loc[16] = {0};
-static size_t loc_sz = 16;
+
 // Tag used for ESP serial console messages
 static const char TAG[] = "http_server";
 
@@ -734,6 +733,9 @@ esp_err_t http_server_device_location_handler(httpd_req_t*req){
 
 	char dbuf[128]={0};
 	char ipType[32]={0};
+	char loc[LOCATION_SIZE + 1] = {0};
+	size_t loc_sz = LOCATION_SIZE;
+
 	nvs_handle handle;
 	esp_err_t esp_err;
 	esp_err = nvs_open("net_config", NVS_READWRITE, &handle);
@@ -776,9 +778,10 @@ esp_err_t http_server_settings_parameters_handler(httpd_req_t*req){
 	return ESP_OK;
 }
 
-esp_err_t http_server_set_device_location_handler(httpd_req_t*req) {
+esp_err_t http_server_set_device_location_handler(httpd_req_t *req) {
 	ESP_LOGI(TAG, "Get device location tag");
 	char content[100] = {0};
+	size_t loc_sz = LOCATION_SIZE;
 
 	int read_len = httpd_req_recv(req, content, MIN(req->content_len, sizeof(content) - 1));
 	if (read_len <= 0)
@@ -787,47 +790,58 @@ esp_err_t http_server_set_device_location_handler(httpd_req_t*req) {
 		return ESP_FAIL;
 	}
 
-    cJSON *json = cJSON_Parse(content);
-    if (json == NULL)
-    {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to parse JSON payload");
-        return ESP_FAIL;
-    }
-    cJSON *dev_location_Value_json = cJSON_GetObjectItem(json, "device_location");
-    if (dev_location_Value_json == NULL )
-    {
-        cJSON_Delete(json);
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Missing network or password field");
-        printf("error parsing json\r\n");
-        return ESP_FAIL;
-    }
-    const char *dev_location_IpValue = dev_location_Value_json->valuestring;
-	if((strlen(dev_location_Value_json->valuestring) > 1)){
-		printf("RECEIVED : %s\n",dev_location_Value_json->valuestring);
-		strcpy(roomsense_iq_shared.location, dev_location_Value_json->valuestring);
-
-		nvs_handle handle;
-		esp_err_t esp_err;
-		esp_err = nvs_open("net_config", NVS_READWRITE, &handle);
-		esp_err = nvs_set_blob(handle, "dev_loc_tag", dev_location_Value_json->valuestring, 16);
-		if (esp_err != ESP_OK)
-		{
-			nvs_close(handle);
-			const char *response = "failed to update device location tag";
-			httpd_resp_send(req, response, strlen(response));
-			return esp_err;
-		}
-		esp_err = nvs_commit(handle);
-		nvs_close(handle);
-		printf("app_nvs_save_netconfig_settings: returned ESP_OK\n");
-		const char *response = "device location tag updated";
-		httpd_resp_send(req, response, strlen(response));
+	cJSON *json = cJSON_Parse(content);
+	if (json == NULL)
+	{
+		httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to parse JSON payload");
+		return ESP_FAIL;
 	}
-	else {
+
+	cJSON *device_location_json = cJSON_GetObjectItem(json, "device_location");
+	if (device_location_json == NULL || !cJSON_IsString(device_location_json) || device_location_json->valuestring == NULL) // allow empty
+	{
+		cJSON_Delete(json);
+		const char *response = "device_location is missing";
+		httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, response);
+		printf("%s\n", response);
+		return ESP_FAIL;
+	}
+
+	printf("RECEIVED : %s\n", device_location_json->valuestring);
+
+	if (strlen(device_location_json->valuestring) > loc_sz)
+	{
+		cJSON_Delete(json);
+		const char *response = "device location tag exceeds max length";
+		httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, response);
+		printf("%s\n", response);
+		return ESP_FAIL;
+	}
+
+	memset(&roomsense_iq_shared.location, 0x00, loc_sz + 1);
+	strcpy(roomsense_iq_shared.location, device_location_json->valuestring);
+
+	cJSON_Delete(json);
+
+	nvs_handle handle;
+	esp_err_t esp_err;
+	esp_err = nvs_open("net_config", NVS_READWRITE, &handle);
+	esp_err = nvs_set_blob(handle, "dev_loc_tag", roomsense_iq_shared.location, loc_sz);
+	if (esp_err != ESP_OK)
+	{
+		nvs_close(handle);
 		const char *response = "failed to update device location tag";
 		httpd_resp_send(req, response, strlen(response));
+		return esp_err;
 	}
-    cJSON_Delete(json);
+
+	esp_err = nvs_commit(handle);
+	nvs_close(handle);
+
+	const char *response = "device location tag updated";
+	httpd_resp_send(req, response, HTTPD_RESP_USE_STRLEN);
+	printf("%s\n", response);
+
 	return ESP_OK;
 }
 

--- a/firmware/main/http_server.c
+++ b/firmware/main/http_server.c
@@ -776,20 +776,17 @@ esp_err_t http_server_settings_parameters_handler(httpd_req_t*req){
 	return ESP_OK;
 }
 
-esp_err_t http_server_set_device_location_handler(httpd_req_t*req){
-	ESP_LOGI(TAG,"Get device location tag");
-	char content[100];
-	memset(content, 0, sizeof(content));
-    int content_length = req->content_len;
-    if (content_length > 0)
-    {
-        int read_len = httpd_req_recv(req, content, content_length);
-        if (read_len <= 0)
-        {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
-            return ESP_FAIL;
-        }
-    }
+esp_err_t http_server_set_device_location_handler(httpd_req_t*req) {
+	ESP_LOGI(TAG, "Get device location tag");
+	char content[100] = {0};
+
+	int read_len = httpd_req_recv(req, content, MIN(req->content_len, sizeof(content) - 1));
+	if (read_len <= 0)
+	{
+		httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
+		return ESP_FAIL;
+	}
+
     cJSON *json = cJSON_Parse(content);
     if (json == NULL)
     {
@@ -836,19 +833,15 @@ esp_err_t http_server_set_device_location_handler(httpd_req_t*req){
 
 esp_err_t http_server_network_config_handler(httpd_req_t *req)
 {
-    char content[100];
-	memset(content, 0, sizeof(content));
+    char content[100] = {0};
 
-    int content_length = req->content_len;
-    if (content_length > 0)
+    int read_len = httpd_req_recv(req, content, MIN(req->content_len, sizeof(content) - 1));
+    if (read_len <= 0)
     {
-        int read_len = httpd_req_recv(req, content, content_length);
-        if (read_len <= 0)
-        {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
-            return ESP_FAIL;
-        }
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
+        return ESP_FAIL;
     }
+
     cJSON *json = cJSON_Parse(content);
     if (json == NULL)
     {
@@ -917,20 +910,16 @@ esp_err_t http_server_network_config_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
-esp_err_t access_point_state_handler(httpd_req_t *req){
-	char content[100];
-	memset(content, 0, sizeof(content));
+esp_err_t access_point_state_handler(httpd_req_t *req) {
+	char content[100] = {0};
 
-    int content_length = req->content_len;
-    if (content_length > 0)
-    {
-        int read_len = httpd_req_recv(req, content, content_length);
-        if (read_len <= 0)
-        {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
-            return ESP_FAIL;
-        }
-    }
+	int read_len = httpd_req_recv(req, content, MIN(req->content_len, sizeof(content) - 1));
+	if (read_len <= 0)
+	{
+		httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
+		return ESP_FAIL;
+	}
+
 	printf("received %s\r\n",content);
     cJSON *json = cJSON_Parse(content);
     if (json == NULL)
@@ -994,20 +983,16 @@ esp_err_t access_point_state_handler(httpd_req_t *req){
 }
 
 
-esp_err_t led_state_handler(httpd_req_t *req){
-	char content[100];
-	memset(content, 0, sizeof(content));
+esp_err_t led_state_handler(httpd_req_t *req) {
+	char content[100] = {0};
 
-    int content_length = req->content_len;
-    if (content_length > 0)
-    {
-        int read_len = httpd_req_recv(req, content, content_length);
-        if (read_len <= 0)
-        {
-            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
-            return ESP_FAIL;
-        }
-    }
+	int read_len = httpd_req_recv(req, content, MIN(req->content_len, sizeof(content) - 1));
+	if (read_len <= 0)
+	{
+		httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Failed to read request payload");
+		return ESP_FAIL;
+	}
+
     cJSON *json = cJSON_Parse(content);
     if (json == NULL)
     {

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -31,7 +31,7 @@ static const char *TAG = "MAIN";
 roomsense_iq roomsense_iq_shared =
 {
 	 .ap_key                     = "password",  // Initialize with "password"
-	 .location                   = { },
+	 .location                   = {0},
 	 .led_enable                 = true,
 	 .ap_enable                  = true,
 	 .alert_flag                 = false,
@@ -41,8 +41,8 @@ roomsense_iq roomsense_iq_shared =
 	 .t_h_co2_connection         = false,
 	 .voc_connection             = false,
 	 .pm_connection              = false,
-	 .ld2410_config_shared       = { },
-	 .ld2410_data_shared         = { },
+	 .ld2410_config_shared       = {0},
+	 .ld2410_data_shared         = {0},
 	 .buttons_shared             = { .g_button_get_config = false, .g_button_set_config = false, .g_button_factory_reset = false, .g_button_config_to_pir = false },
 	 .adafruit_161_shared        = { .light_density_raw = 0 },
 	 .direction_detection_shared = { .macro_movement = 0, .g_movement_direction = 0 },
@@ -158,8 +158,8 @@ esp_err_t load_location()
 {
 	esp_err_t err;
 	nvs_handle handle;
-	static char loc[16] = {0};
-	static size_t loc_sz = 16;
+	char loc[LOCATION_SIZE + 1] = {0};
+	size_t loc_sz = LOCATION_SIZE;
 
 	err = nvs_open("net_config", NVS_READWRITE, &handle);
 	if (err != ESP_OK)

--- a/firmware/main/tasks_common.h
+++ b/firmware/main/tasks_common.h
@@ -126,6 +126,7 @@
 #define MAX_MQTT_PUBLISH_LENGTH             20
 
 #define MAC_ADDRESS_LENGTH                  15
+#define LOCATION_SIZE                       32
 
 extern SemaphoreHandle_t baseline_semaphore;
 extern SemaphoreHandle_t blindspot_semaphore;

--- a/firmware/main/webpage/index.html
+++ b/firmware/main/webpage/index.html
@@ -28,17 +28,39 @@
 					console.log(xhr.responseText);
 					let json = JSON.parse(xhr.responseText);
 					console.log(json);
-					if(json.device_location != null)document.getElementById('current_location').textContent = json.device_location;
-					else document.getElementById('current_location').textContent = "NotSet";
-					if(json.ipType != null){
-						if(json.ipType === 'static')document.getElementById('ipsetting_state').textContent = "Current Setting: "+ "Static IP Address";
-						else if(json.ipType === 'dynamic')document.getElementById('ipsetting_state').textContent = "Current Setting: "+ "Dynamic IP Address";
+
+					var current_location;
+					if (json.device_location != null && json.device_location.length) {
+						current_location = json.device_location;
 					}
-					
-					else document.getElementById('ipsetting_state').textContent = "(Default:Dynamic)";
-				} 
+					else {
+						current_location = 'Not Set';
+					}
+
+					document.getElementById('current_location').textContent = current_location;
+
+					var ipsetting;
+					if (json.ipType != null && json.ipType.length) {
+						if (json.ipType === 'static') {
+							ipsetting = 'Static IP Address';
+						}
+						else if (json.ipType === 'dynamic') {
+							ipsetting = 'Dynamic IP Address';
+						}
+						else {
+							ipsetting = 'Invalid';
+						}
+
+						ipsetting = `Current Setting: ${ipsetting}`;
+					}
+					else {
+						ipsetting = '(Default:Dynamic)';
+					}
+
+					document.getElementById('ipsetting_state').textContent = ipsetting;
+				}
 				else {
-				console.error('Request failed with status:', xhr.status);
+					console.error('Request failed with status:', xhr.status);
 				}
 			}
 			};
@@ -179,13 +201,36 @@
 			xhr.send(data);
 		}
 
-			//document.addEventListener('DOMContentLoaded', function() {
-			function update_device_location(){
-				document.getElementById('device_location_txt').style.display = "block";
-				document.getElementById('device_location_submit').value = "submit";
-				var device_location_content = document.getElementById('device_location_txt').value;
+			function show_location_input(location) {
+				document.getElementById('device_location_txt').value = location;
+				document.getElementById('device_location_txt').style.display = 'block';
+				document.getElementById('device_location_submit').value = 'Submit';
+				document.getElementById('device_location_submit').setAttribute('onclick', 'update_device_location(1)');
+			}
+
+			function hide_location_input() {
+				document.getElementById('device_location_txt').style.display = 'none';
+				document.getElementById('device_location_submit').value = 'Location Tag';
+				document.getElementById('device_location_submit').setAttribute('onclick', 'update_device_location()');
+			}
+
+			function update_device_location(submit) {
+				var current_location = document.getElementById('current_location').textContent == 'Not Set' ? '' : document.getElementById('current_location').textContent;
+
+				if (!submit) {
+					show_location_input(current_location);
+					return;
+				}
+
+				var new_location = document.getElementById('device_location_txt').value;
+
+				if (current_location == new_location) {
+					hide_location_input();
+					return;
+				}
+
 				var data = JSON.stringify({
-					device_location : device_location_content
+					device_location: new_location
 				});
 				console.log(data);
 				var xhr = new XMLHttpRequest();
@@ -193,16 +238,16 @@
 				xhr.setRequestHeader("Content-Type", "application/json");
 				xhr.onreadystatechange = function () {
 					if (xhr.readyState === 4 && xhr.status === 200) {
-						document.getElementById('current_location').textContent = device_location_content;
+						document.getElementById('current_location').textContent = new_location.length ? new_location : 'Not Set';
 						console.log('Success:', xhr.responseText);
-						// Handle success response from the server if needed
+						hide_location_input();
 					} else if (xhr.readyState === 4 && xhr.status !== 200) {
-						console.error('Error:', xhr.responseText);
-						// Handle error if the request fails
+						var error = `Error: ${xhr.responseText}`;
+						console.error(error);
+						alert(error);
 					}
 				};
 				xhr.send(data);
-				console.log("click");
 			};
 
 			// document.addEventListener('DOMContentLoaded', function() {
@@ -281,7 +326,7 @@
 	</header>
 	<div id = "location_tag" >
 		<label style="color: #4a89e0; font-weight:bolder; font-size: large;"> Location:  </label>
-		<label id = 'current_location' style="color: #79b1ff; font-weight:bolder; font-size: large;"> Not Set </label>
+		<label id = 'current_location' style="color: #79b1ff; font-weight:bolder; font-size: large;"></label>
 	</div>
 	<hr>
 	<div id="OTA">
@@ -425,8 +470,8 @@
 	</div>
 	
 	<div style="margin-left: 10px; margin-top: -8px;">
-		<input id = 'device_location_txt' type = "text" style="display: none;">	
-		<input id = "device_location_submit" type="button" value="Location Tag" onclick="update_device_location()">
+		<input id='device_location_txt' type="text" maxlength="32" style="display: none;">
+		<input id="device_location_submit" type="button" value="Location Tag" onclick="update_device_location()">
 	</div>
 	</div>
 	</body>

--- a/firmware/main/wifi_app.c
+++ b/firmware/main/wifi_app.c
@@ -129,8 +129,7 @@ static void wifi_app_event_handler(void *arg, esp_event_base_t event_base, int32
 			case WIFI_EVENT_STA_DISCONNECTED: //station disconnect
 				ESP_LOGI(TAG, "WIFI_EVENT_STA_DISCONNECTED");
 				ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA)); // Enable AP again when network disconnects
-				wifi_event_sta_disconnected_t *wifi_event_sta_disconnected = (wifi_event_sta_disconnected_t*)malloc(sizeof(wifi_event_sta_disconnected_t));
-				*wifi_event_sta_disconnected = *((wifi_event_sta_disconnected_t*)event_data);
+				const wifi_event_sta_disconnected_t *wifi_event_sta_disconnected = (const wifi_event_sta_disconnected_t *)event_data;
 				ESP_LOGE(TAG, "WIFI_EVENT_STA_DISCONNECTED, reason code %d, retries %d", wifi_event_sta_disconnected->reason, g_retry_number);
 
 				EventBits_t eventBits = xEventGroupGetBits(wifi_app_event_group);

--- a/firmware/main/wifi_app.h
+++ b/firmware/main/wifi_app.h
@@ -12,7 +12,7 @@
 #include "freertos/event_groups.h"
 
 // WiFi application settings
-#define WIFI_AP_SSID				"RoomSense-ECDA3B9D6C14"		// AP name
+#define WIFI_AP_SSID				"RoomSense-"		// AP name prefix
 #define WIFI_AP_PASSWORD			"password"			// AP password
 #define WIFI_AP_CHANNEL				1					// AP channel
 #define WIFI_AP_SSID_HIDDEN			0					// AP visibility


### PR DESCRIPTION
Here's a several fixes that I've rearranged (from their original chronological commit times) into different functional areas:

WiFI:
- Remove limit of 5 wifi connect retries
- Fix memory leak during each wifi disconnect
- Workaround for race condition on wifi disconnect

MQTT:
- Fix stack corruption in MQTT handling
- Fix memory leaks during MQTT reconnect
- Don't re-save MQTT creds to flash on each disconnect

HTTP:
- Avoid buffer overflow when handling HTTP payloads

Location:
- More consistently put together SoftAP SSIDs
- Allow location tags up to 32 characters
- Don't submit location data unless in "submit" mode

Note that I reworked "Fix stack corruption in MQTT handling" significantly tonight versus what was there before in my "community" branch as I found some issues with my previous approach; but, I was able to short-circuit most of it anyways as the firmware currently doesn't subscribe to any MQTT topics (they're all already commented out).